### PR TITLE
Do not swallow interruption request

### DIFF
--- a/src/main/java/de/jkeylockmanager/manager/implementation/lockstripe/CountingLock.java
+++ b/src/main/java/de/jkeylockmanager/manager/implementation/lockstripe/CountingLock.java
@@ -109,6 +109,7 @@ final class CountingLock {
 				throw new KeyLockManagerTimeoutException(lockTimeout, lockTimeoutUnit);
 			}
 		} catch (final InterruptedException e) {
+			Thread.currentThread().interrupt();
 			throw new KeyLockManagerInterruptedException();
 		}
 	}


### PR DESCRIPTION
See
https://stackoverflow.com/questions/4906799/why-invoke-thread-currentthread-interrupt-in-a-catch-interruptexception-block/4906814